### PR TITLE
Renamed actions and added level parameter to all actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
-## In progress
+## 0.3.0 In progress
+
+### Breaking Changes
+
+ * Renamed the following methods to match the `level` parameter they now optionally receive:
+    * `fail_when_wrong_branching_model` to `check_wrong_branching_model`
+    * `fail_when_non_single_commit_feature` to `check_non_single_commit_feature`
+    * `fail_when_changelog_update_missing` to `check_changelog_update_missing`
+    * `fail_when_merge_commit_detected` to `check_merge_commit_detected`
+    * `warn_when_work_in_progess_pr` to `check_work_in_progess_pr`
 
 #### Features
 
- *
+ * Added `level` parameter to all actions to personnalize the report level 
+   (`:fail`, `:warn`, `:message`) if the check fails. 
+
+ * Added `have_message` and `have_no_message` matchers.
 
  *
 
@@ -14,7 +26,9 @@
 
  *
 
- *
+#### Support
+
+ * Fixed grammatical errors in the `README.md`.
 
 #### Support
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -7,13 +7,13 @@ samsao.config do
 end
 
 ## Errors
-samsao.fail_when_changelog_update_missing
-samsao.fail_when_merge_commit_detected
-samsao.fail_when_non_single_commit_feature
-samsao.fail_when_wrong_branching_model
+samsao.check_changelog_update_missing
+samsao.check_merge_commit_detected
+samsao.check_non_single_commit_feature
+samsao.check_wrong_branching_model
 
 ## Warnings
-samsao.warn_when_work_in_progess_pr
+samsao.check_work_in_progess_pr
 
 ## Messages
 unless status_report[:errors].empty?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-samsao (0.2.1.pre1)
+    danger-samsao (0.3.0.pre1)
       danger-plugin-api (~> 1.0)
 
 GEM
@@ -134,4 +134,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.14.4
+   1.14.6

--- a/lib/samsao/gem_version.rb
+++ b/lib/samsao/gem_version.rb
@@ -1,3 +1,3 @@
 module Samsao
-  VERSION = '0.2.1.pre1'.freeze
+  VERSION = '0.3.0.pre1'.freeze
 end

--- a/lib/samsao/regexp.rb
+++ b/lib/samsao/regexp.rb
@@ -4,7 +4,7 @@ module Samsao
     # Turns a source entry input into a Regexp. Uses rules from [from_matcher](#from_matcher)
     # function and append a `^` to final regexp when the source if a pure String.
     #
-    # @param matcher The source entry to transform into a Regexp
+    # @param source The source entry to transform into a Regexp
     #
     # @return [Regexp] The source entry as a regexp
     def self.from_source(source)

--- a/spec/matchers/have_message.rb
+++ b/spec/matchers/have_message.rb
@@ -1,0 +1,25 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_message do |expected|
+  match do |actual|
+    actual.status_report[:messages].any? do |message|
+      expected.is_a?(Regexp) ? message =~ matcher : message.start_with?(expected)
+    end
+  end
+
+  failure_message do |actual|
+    result = "expected that #{Danger} would have warning '#{expected}'"
+
+    messages = actual.status_report[:messages]
+    if messages.empty?
+      result += ' but there is none'
+      return result
+    end
+
+    actual.status_report[:messages].each do |message|
+      result += "\n * #{message}"
+    end
+
+    result
+  end
+end

--- a/spec/matchers/have_no_message.rb
+++ b/spec/matchers/have_no_message.rb
@@ -1,0 +1,14 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_no_message do
+  match do |actual|
+    actual.status_report[:messages].empty?
+  end
+
+  failure_message do |actual|
+    result = "expected that #{Danger} would have no message but found '#{actual.status_report[:messages].size}'"
+    actual.status_report[:messages].each do |message|
+      result += "\n * #{message}"
+    end
+  end
+end

--- a/spec/samsao_branching_model_spec.rb
+++ b/spec/samsao_branching_model_spec.rb
@@ -15,7 +15,7 @@ module Danger
           it "continues on #{branch_prefix}/ prefix" do
             allow(@plugin.github).to receive(:branch_for_head).and_return("#{branch_prefix}/something")
 
-            @plugin.fail_when_wrong_branching_model
+            @plugin.check_wrong_branching_model
 
             expect(@dangerfile).to have_no_error
           end
@@ -24,7 +24,7 @@ module Danger
         it 'fails on wrong prefix' do
           allow(@plugin.github).to receive(:branch_for_head).and_return('wrong/12')
 
-          @plugin.fail_when_wrong_branching_model
+          @plugin.check_wrong_branching_model
 
           expect(@dangerfile).to have_error(@wrong_branching_model)
         end
@@ -32,7 +32,7 @@ module Danger
         it 'fails on good prefix but wrong format' do
           allow(@plugin.github).to receive(:branch_for_head).and_return('feature_12')
 
-          @plugin.fail_when_wrong_branching_model
+          @plugin.check_wrong_branching_model
 
           expect(@dangerfile).to have_error(@wrong_branching_model)
         end

--- a/spec/samsao_changelog_updated_spec.rb
+++ b/spec/samsao_changelog_updated_spec.rb
@@ -15,7 +15,7 @@ module Danger
         it 'continues on support branch' do
           allow(@plugin.github).to receive(:branch_for_head).and_return('support/a')
 
-          @plugin.fail_when_changelog_update_missing
+          @plugin.check_changelog_update_missing
 
           expect(@dangerfile).to have_no_error
         end
@@ -25,7 +25,7 @@ module Danger
             allow(@plugin.github).to receive(:branch_for_head).and_return("#{branch}/a")
             allow(@plugin.git).to receive(:modified_files).and_return(['CHANGELOG.md'])
 
-            @plugin.fail_when_changelog_update_missing
+            @plugin.check_changelog_update_missing
 
             expect(@dangerfile).to have_no_error
           end
@@ -34,7 +34,7 @@ module Danger
             allow(@plugin.github).to receive(:branch_for_head).and_return("#{branch}/a")
             allow(@plugin.git).to receive(:modified_files).and_return([])
 
-            @plugin.fail_when_changelog_update_missing
+            @plugin.check_changelog_update_missing
 
             expect(@dangerfile).to have_error(@changelog_needs_update)
           end
@@ -48,7 +48,7 @@ module Danger
           allow(@plugin.github).to receive(:branch_for_head).and_return('fix/a')
           allow(@plugin.git).to receive(:modified_files).and_return(['CHANGELOG.yml'])
 
-          @plugin.fail_when_changelog_update_missing
+          @plugin.check_changelog_update_missing
 
           expect(@dangerfile).to have_no_error
         end
@@ -61,7 +61,7 @@ module Danger
           allow(@plugin.github).to receive(:branch_for_head).and_return('fix/a')
           allow(@plugin.git).to receive(:modified_files).and_return(['web/CHANGELOG.md'])
 
-          @plugin.fail_when_changelog_update_missing
+          @plugin.check_changelog_update_missing
 
           expect(@dangerfile).to have_no_error
         end
@@ -70,7 +70,7 @@ module Danger
           allow(@plugin).to receive(:trivial_change?).and_return(true)
           allow(@plugin.git).to receive(:modified_files).and_return([])
 
-          @plugin.fail_when_changelog_update_missing
+          @plugin.check_changelog_update_missing
 
           expect(@dangerfile).to have_no_error
         end
@@ -83,7 +83,7 @@ module Danger
           allow(@plugin).to receive(:support_branch?).and_return(true)
           allow(@plugin.git).to receive(:modified_files).and_return([])
 
-          @plugin.fail_when_changelog_update_missing
+          @plugin.check_changelog_update_missing
 
           expect(@dangerfile).to have_no_error
         end
@@ -96,7 +96,7 @@ module Danger
           allow(@plugin).to receive(:support_branch?).and_return(true)
           allow(@plugin.git).to receive(:modified_files).and_return([])
 
-          @plugin.fail_when_changelog_update_missing
+          @plugin.check_changelog_update_missing
 
           expect(@dangerfile).to have_error(@changelog_needs_update)
         end

--- a/spec/samsao_feature_single_commit_spec.rb
+++ b/spec/samsao_feature_single_commit_spec.rb
@@ -14,7 +14,7 @@ module Danger
           allow(@plugin.github).to receive(:branch_for_head).and_return('feature/a')
           allow(@plugin.git).to receive(:commits).and_return(['sha1'])
 
-          @plugin.fail_when_non_single_commit_feature
+          @plugin.check_non_single_commit_feature
 
           expect(@dangerfile).to have_no_error
         end
@@ -23,7 +23,7 @@ module Danger
           allow(@plugin.github).to receive(:branch_for_head).and_return('fix/a')
           allow(@plugin.git).to receive(:commits).and_return(['sha1', 'sha2'])
 
-          @plugin.fail_when_non_single_commit_feature
+          @plugin.check_non_single_commit_feature
 
           expect(@dangerfile).to have_no_error
         end
@@ -32,7 +32,7 @@ module Danger
           allow(@plugin.github).to receive(:branch_for_head).and_return('feature/a')
           allow(@plugin.git).to receive(:commits).and_return(['sha1', 'sha2'])
 
-          @plugin.fail_when_non_single_commit_feature
+          @plugin.check_non_single_commit_feature
 
           expect(@dangerfile).to have_error(@must_have_single_commit)
         end

--- a/spec/samsao_merge_commit_detected_spec.rb
+++ b/spec/samsao_merge_commit_detected_spec.rb
@@ -15,7 +15,7 @@ module Danger
         it 'continues when no commits' do
           allow(@plugin.git).to receive(:commits).and_return([])
 
-          @plugin.fail_when_merge_commit_detected
+          @plugin.check_merge_commit_detected
 
           expect(@dangerfile).to have_no_error
         end
@@ -26,7 +26,7 @@ module Danger
             commit('two'),
           ])
 
-          @plugin.fail_when_merge_commit_detected
+          @plugin.check_merge_commit_detected
 
           expect(@dangerfile).to have_no_error
         end
@@ -37,7 +37,7 @@ module Danger
             commit("Merge branch 'develop'"),
           ])
 
-          @plugin.fail_when_merge_commit_detected
+          @plugin.check_merge_commit_detected
 
           expect(@dangerfile).to have_error(@merge_commits_detected)
         end
@@ -48,7 +48,7 @@ module Danger
             commit("Merge branch 'develop'"),
           ])
 
-          @plugin.fail_when_merge_commit_detected
+          @plugin.check_merge_commit_detected
 
           expect(@dangerfile).to have_error(@merge_commits_detected)
         end
@@ -59,7 +59,7 @@ module Danger
             commit("Merge branch 'test'"),
           ])
 
-          @plugin.fail_when_merge_commit_detected
+          @plugin.check_merge_commit_detected
 
           expect(@dangerfile).to have_error(@merge_commits_detected)
         end

--- a/spec/samsao_report_spec.rb
+++ b/spec/samsao_report_spec.rb
@@ -1,0 +1,45 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+module Danger
+  describe Danger::DangerSamsao do
+    describe 'with Dangerfile' do
+      before do
+        @dangerfile = testing_dangerfile
+        @plugin = @dangerfile.samsao
+        @content = 'Message'
+      end
+
+      describe 'report' do
+        it 'send fail' do
+          @plugin.report(:fail, @content)
+          expect(@dangerfile).to have_error(@content)
+          expect(@dangerfile).to have_no_warning
+          expect(@dangerfile).to have_no_message
+        end
+
+        it 'send warn' do
+          @plugin.report(:warn, @content)
+          expect(@dangerfile).to have_warning(@content)
+          expect(@dangerfile).to have_no_error
+          expect(@dangerfile).to have_no_message
+        end
+
+        it 'send message' do
+          @plugin.report(:message, @content)
+          expect(@dangerfile).to have_message(@content)
+          expect(@dangerfile).to have_no_warning
+          expect(@dangerfile).to have_no_error
+        end
+
+        it 'send unknown level' do
+          level = 'unknown'
+          error = "Report level '#{level}' is invalid."
+          expect { @plugin.report(level, @content) }.to raise_error(error)
+          expect(@dangerfile).to have_no_warning
+          expect(@dangerfile).to have_no_error
+          expect(@dangerfile).to have_no_message
+        end
+      end
+    end
+  end
+end

--- a/spec/samsao_work_in_progress_pr_spec.rb
+++ b/spec/samsao_work_in_progress_pr_spec.rb
@@ -16,7 +16,7 @@ module Danger
         it 'warns when PR title contains [WIP] at the end' do
           allow(@plugin.github).to receive(:pr_title).and_return('Marker at the end [WIP]')
 
-          @plugin.warn_when_work_in_progess_pr
+          @plugin.check_work_in_progess_pr
 
           expect(@dangerfile).to have_warning(@work_in_progress)
         end
@@ -24,7 +24,7 @@ module Danger
         it 'warns when PR title contains [WIP] at the start' do
           allow(@plugin.github).to receive(:pr_title).and_return('[WIP] Marker at start')
 
-          @plugin.warn_when_work_in_progess_pr
+          @plugin.check_work_in_progess_pr
 
           expect(@dangerfile).to have_warning(@work_in_progress)
         end
@@ -32,7 +32,7 @@ module Danger
         it 'warns when PR title contains [WIP] in the middle' do
           allow(@plugin.github).to receive(:pr_title).and_return('Marker in [WIP] the middle')
 
-          @plugin.warn_when_work_in_progess_pr
+          @plugin.check_work_in_progess_pr
 
           expect(@dangerfile).to have_warning(@work_in_progress)
         end
@@ -40,7 +40,7 @@ module Danger
         it 'continues when PR title does not contain [WIP] marker' do
           allow(@plugin.github).to receive(:pr_title).and_return('A WIP PR')
 
-          @plugin.warn_when_work_in_progess_pr
+          @plugin.check_work_in_progess_pr
 
           expect(@dangerfile).to have_no_warning
         end


### PR DESCRIPTION
 * Renamed the following methods to match the `type` parameter they now optionally receive:
    * `fail_when_wrong_branching_model` to `check_wrong_branching_model`
    * `fail_when_non_single_commit_feature` to `check_non_single_commit_feature`
    * `fail_when_changelog_update_missing` to `check_changelog_update_missing`
    * `fail_when_merge_commit_detected` to `check_merge_commit_detected`
    * `warn_when_work_in_progess_pr` to `check_work_in_progess_pr` 

 * Added `type` parameter to all actions to personnalize the report type 
   (`:fail`, `:warn`, `:message`) if the check fails. 
   
 * Added `have_message` and `have_no_message` matchers.