### PR TITLE
Updated helpers to support McKesson branch models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 #### Features
 
- *
+ * Changed the following helpers to support `2.0.0/feature/a` and `other-app/feature/a` branch models:
+    * `feature_branch?`
+    * `fix_branch?`
+    * `release_branch?`
+    * `support_branch?`
+
+ * Added details to error messages to clarify them.
 
 ## 0.3.0 (August 23, 2017)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-samsao (0.3.1)
+    danger-samsao (0.3.1.pre1)
       danger-plugin-api (~> 1.0)
 
 GEM

--- a/lib/samsao/actions.rb
+++ b/lib/samsao/actions.rb
@@ -72,7 +72,7 @@ module Samsao
       return if samsao.trivial_change? || !samsao.feature_branch?
       return report(:fail, 'Your Danger config is missing a `jira_project_key` value.') unless jira_project_key?
 
-      message = 'The PR must starts with JIRA issue number between square brackets'\
+      message = 'The PR title must starts with JIRA issue number between square brackets'\
                 " (i.e. [#{config.jira_project_key}-XXX])."
 
       report(level, message) unless contains_jira_issue_number?(github.pr_title)
@@ -102,7 +102,7 @@ module Samsao
     def check_acceptance_criteria(level = :warn)
       return unless samsao.feature_branch?
 
-      message = 'The PR should have the acceptance criteria in the body.'
+      message = 'The PR description should have the acceptance criteria in the body.'
 
       report(level, message) if (/acceptance criteria/i =~ github.pr_body).nil?
     end
@@ -156,7 +156,7 @@ module Samsao
     def check_commit_contains_jira_issue_number(commit, type)
       commit_id = "#{shorten_sha(commit.sha)} ('#{truncate(commit.message)}')"
       jira_project_key = config.jira_project_key
-      message = "The commit #{commit_id} should contain JIRA issue number" \
+      message = "The commit message #{commit_id} should contain JIRA issue number" \
       " between square brackets (i.e. [#{jira_project_key}-XXX]), multiple allowed" \
       " (i.e. [#{jira_project_key}-XXX, #{jira_project_key}-YYY, #{jira_project_key}-ZZZ])"
 

--- a/lib/samsao/gem_version.rb
+++ b/lib/samsao/gem_version.rb
@@ -1,3 +1,3 @@
 module Samsao
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.1.pre1'.freeze
 end

--- a/lib/samsao/helpers.rb
+++ b/lib/samsao/helpers.rb
@@ -20,15 +20,16 @@ module Samsao
     # @return [Bool]
     #
     def feature_branch?
-      git_branch.start_with?('feature/')
+      !(%r{^#{GIT_BRANCH_PREFIX}feature/\w} =~ git_branch).nil?
     end
 
-    # Return true if the current PR branch is a bug fix branch.
+    # Return true if the current PR branch is a bug fix branch. Accepts `fix`,
+    # `bugfix`, `hotfix`, `coldfix` and `warmfix`.
     #
     # @return [Bool]
     #
     def fix_branch?
-      !(%r{^(bug|hot)?fix/} =~ git_branch).nil?
+      !(%r{^#{GIT_BRANCH_PREFIX}(bug|cold|warm|hot)?fix/\w} =~ git_branch).nil?
     end
 
     # Return true if the current PR branch is a release branch.
@@ -36,7 +37,7 @@ module Samsao
     # @return [Bool]
     #
     def release_branch?
-      git_branch.start_with?('release/')
+      !(%r{^#{GIT_BRANCH_PREFIX}release/\w} =~ git_branch).nil?
     end
 
     # Return true if the current PR branch is a support branch.
@@ -44,7 +45,7 @@ module Samsao
     # @return [Bool]
     #
     def support_branch?
-      git_branch.start_with?('support/')
+      !(%r{^#{GIT_BRANCH_PREFIX}support/\w} =~ git_branch).nil?
     end
 
     # Return true if the current PR is a trivial change, i.e. if PR title contains #trivial or #typo markers.
@@ -112,6 +113,8 @@ module Samsao
     end
 
     private
+
+    GIT_BRANCH_PREFIX = '([-a-z0-9._]+/)?'.freeze
 
     def git_branch
       github.branch_for_head

--- a/spec/samsao_acceptance_criteria_spec.rb
+++ b/spec/samsao_acceptance_criteria_spec.rb
@@ -6,7 +6,7 @@ module Danger
       before do
         @dangerfile = testing_dangerfile
         @plugin = @dangerfile.samsao
-        @message = 'The PR should have the acceptance criteria in the body.'
+        @message = 'The PR description should have the acceptance criteria in the body.'
       end
 
       describe 'check acceptance criteria' do

--- a/spec/samsao_branch_helper_spec.rb
+++ b/spec/samsao_branch_helper_spec.rb
@@ -12,7 +12,11 @@ module Danger
         it 'supports feature_branch? correctly' do
           data_set = [
             { branch: 'feature/a', expected: true },
+            { branch: '2.0.0/feature/a', expected: true },
+            { branch: 'other_app-name/feature/a', expected: true },
+            { branch: 'something/something-else/feature/a', expected: false },
             { branch: 'fix/a', expected: false },
+            { branch: 'feature/', expected: false },
             { branch: 'random', expected: false },
           ]
 
@@ -28,7 +32,13 @@ module Danger
             { branch: 'fix/a', expected: true },
             { branch: 'bugfix/a', expected: true },
             { branch: 'hotfix/a', expected: true },
+            { branch: 'warmfix/a', expected: true },
+            { branch: 'coldfix/a', expected: true },
+            { branch: '2.0.0/fix/a', expected: true },
+            { branch: 'other_app-name/fix/a', expected: true },
+            { branch: 'something/something-else/fix/a', expected: false },
             { branch: 'otherfix/a', expected: false },
+            { branch: 'fix/', expected: false },
             { branch: 'random', expected: false },
           ]
 
@@ -41,7 +51,11 @@ module Danger
         it 'supports release_branch? correctly' do
           data_set = [
             { branch: 'release/a', expected: true },
+            { branch: '2.0.0/release/a', expected: true },
+            { branch: 'other_app-name/release/a', expected: true },
+            { branch: 'something/something-else/release/a', expected: false },
             { branch: 'fix/a', expected: false },
+            { branch: 'release/', expected: false },
             { branch: 'random', expected: false },
           ]
 
@@ -54,7 +68,11 @@ module Danger
         it 'supports support_branch? correctly' do
           data_set = [
             { branch: 'support/a', expected: true },
+            { branch: '2.0.0/support/a', expected: true },
+            { branch: 'other_app-name/support/a', expected: true },
+            { branch: 'something/something-else/support/a', expected: false },
             { branch: 'fix/a', expected: false },
+            { branch: 'support/', expected: false },
             { branch: 'random', expected: false },
           ]
 

--- a/spec/samsao_feature_jira_issue_number_spec.rb
+++ b/spec/samsao_feature_jira_issue_number_spec.rb
@@ -52,7 +52,7 @@ module Danger
 
         it 'fails on branch with no issue number' do
           jira_project_key = 'VER'
-          message = 'The PR must starts with JIRA issue number between square brackets'\
+          message = 'The PR title must starts with JIRA issue number between square brackets'\
                     " (i.e. [#{jira_project_key}-XXX])."
 
           @plugin.config do

--- a/spec/samsao_fix_jira_issue_number_spec.rb
+++ b/spec/samsao_fix_jira_issue_number_spec.rb
@@ -51,7 +51,7 @@ module Danger
 
           @plugin.check_fix_jira_issue_number
 
-          message = "The commit #{commit_id} should contain JIRA issue number between square brackets"\
+          message = "The commit message #{commit_id} should contain JIRA issue number between square brackets"\
                     " (i.e. [#{jira_project_key}-XXX]), multiple allowed (i.e. [#{jira_project_key}-XXX,"\
                     " #{jira_project_key}-YYY, #{jira_project_key}-ZZZ])"
 


### PR DESCRIPTION
* Updated the following helpers to support `2.0.0/feature/a` and `other-app/feature/a` branch models: 
    * `feature_branch?` 
    * `fix_branch?` 
    * `release_branch?` 
    * `support_branch?` 

Fixes #15 .